### PR TITLE
Remove mojave dependency specification

### DIFF
--- a/wallpapper.rb
+++ b/wallpapper.rb
@@ -8,7 +8,6 @@ class Wallpapper < Formula
   head 'https://github.com/mczachurski/wallpapper.git'
 
   depends_on :xcode => :build
-  depends_on :macos => :mojave
 
   def install
     system 'swift', 'build', '--disable-sandbox', '--configuration', 'release'


### PR DESCRIPTION
This is no longer supported by Homebrew,
which gives the following warning:

```
Warning: Calling `depends_on macos: :mojave` is deprecated! There is no replacement.
Please report this issue to the mczachurski/homebrew-wallpapper tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/mczachurski/homebrew-wallpapper/wallpapper.rb:11
```